### PR TITLE
In baku/data_generation/generate_libero.py, It use SAVE_DATA_PATH = P…

### DIFF
--- a/baku/cfgs/dataloader/libero.yaml
+++ b/baku/cfgs/dataloader/libero.yaml
@@ -1,7 +1,7 @@
 bc_dataset:
   _target_: read_data.libero.BCDataset
-  path: "${root_dir}/expert_demos/libero_with_langemb"
-  # path: "${root_dir}/expert_demos/libero"
+  # path: "${root_dir}/expert_demos/libero_with_langemb"
+  path: "${root_dir}/expert_demos/libero"
   suite: ${suite.task.suite}
   scenes: ${suite.task.scenes}
   tasks: ${suite.task.tasks}


### PR DESCRIPTION
…ath("../../expert_demos/libero") to save .pkl files. However, in baku/cfgs/dataloader/libero.yaml, it path: "${root_dir}/expert_demos/libero_with_langemb" to read .pkl files. However the instruction Instructions.md doesn't say this, "python train.py agent=baku suite=libero dataloader=libero suite/task=libero_90 suite.hidden_dim=256" will fail. This commit tries to fix it.